### PR TITLE
Add franchisee dashboard and job tracking features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+app/app.db
+app/static/uploads/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
-# Startup Saas Solution
-Mobile app for service based startups
+# Startup SaaS Solution
+
+Simple Flask prototype for a pressure washing franchise.
+
+Features:
+
+- Secure login for franchisees and admin
+- Franchisee dashboard with links to calendar, performance metrics and order form
+- Calendar shows jobs scheduled for the next week
+- Performance page summarizes total sales and averages
+- Make an order form captures customer info, images and payment proof

--- a/app/app.py
+++ b/app/app.py
@@ -1,0 +1,186 @@
+import os
+from datetime import datetime, timedelta
+from flask import Flask, render_template, redirect, url_for, request, flash
+from flask_sqlalchemy import SQLAlchemy
+from flask_login import (
+    LoginManager,
+    login_user,
+    login_required,
+    logout_user,
+    current_user,
+    UserMixin,
+)
+
+basedir = os.path.abspath(os.path.dirname(__file__))
+app = Flask(__name__)
+app.config['SECRET_KEY'] = 'secret-key'
+app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///' + os.path.join(basedir, 'app.db')
+app.config['UPLOAD_FOLDER'] = os.path.join(basedir, 'static', 'uploads')
+
+db = SQLAlchemy(app)
+login_manager = LoginManager(app)
+login_manager.login_view = 'login'
+
+# models
+class User(db.Model, UserMixin):
+    id = db.Column(db.Integer, primary_key=True)
+    username = db.Column(db.String(150), unique=True, nullable=False)
+    password = db.Column(db.String(150), nullable=False)
+    role = db.Column(db.String(50), nullable=False)  # 'admin' or 'franchisee'
+
+class Sale(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
+    description = db.Column(db.Text, nullable=False)
+    before_image = db.Column(db.String(150))
+    after_image = db.Column(db.String(150))
+    proof_image = db.Column(db.String(150))
+    address = db.Column(db.String(150))
+    zip_code = db.Column(db.String(10))
+    customer_first = db.Column(db.String(150))
+    customer_last = db.Column(db.String(150))
+    phone = db.Column(db.String(20))
+    payment_method = db.Column(db.String(20))
+    price = db.Column(db.Float)
+    timestamp = db.Column(db.DateTime, default=datetime.utcnow)
+
+class Job(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
+    title = db.Column(db.String(150))
+    scheduled_for = db.Column(db.Date)
+
+@login_manager.user_loader
+def load_user(user_id):
+    return User.query.get(int(user_id))
+
+@app.before_first_request
+def create_tables():
+    db.create_all()
+    os.makedirs(app.config['UPLOAD_FOLDER'], exist_ok=True)
+    if not User.query.filter_by(username='admin').first():
+        admin = User(username='admin', password='admin', role='admin')
+        db.session.add(admin)
+        db.session.commit()
+
+@app.route('/')
+def index():
+    if current_user.is_authenticated:
+        if current_user.role == 'admin':
+            return redirect(url_for('admin_dashboard'))
+        return redirect(url_for('dashboard'))
+    return redirect(url_for('login'))
+
+@app.route('/login', methods=['GET', 'POST'])
+def login():
+    if request.method == 'POST':
+        username = request.form['username']
+        password = request.form['password']
+        user = User.query.filter_by(username=username, password=password).first()
+        if user:
+            login_user(user)
+            return redirect(url_for('index'))
+        flash('Invalid credentials')
+    return render_template('login.html')
+
+@app.route('/logout')
+@login_required
+def logout():
+    logout_user()
+    return redirect(url_for('login'))
+
+@app.route('/dashboard')
+@login_required
+def dashboard():
+    if current_user.role != 'franchisee':
+        return redirect(url_for('admin_dashboard'))
+    sales = Sale.query.filter_by(user_id=current_user.id).all()
+    return render_template('dashboard.html', sales=sales)
+
+
+@app.route('/calendar')
+@login_required
+def calendar():
+    if current_user.role != 'franchisee':
+        return redirect(url_for('admin_dashboard'))
+    today = datetime.utcnow().date()
+    next_week = today + timedelta(days=7)
+    jobs = Job.query.filter(
+        Job.user_id == current_user.id,
+        Job.scheduled_for >= today,
+        Job.scheduled_for <= next_week,
+    ).all()
+    return render_template('calendar.html', jobs=jobs)
+
+
+@app.route('/performance')
+@login_required
+def performance():
+    if current_user.role != 'franchisee':
+        return redirect(url_for('admin_dashboard'))
+    sales = Sale.query.filter_by(user_id=current_user.id).all()
+    total = sum(s.price for s in sales if s.price)
+    count = len(sales)
+    avg = total / count if count else 0
+    return render_template(
+        'performance.html', total=total, count=count, average=avg
+    )
+
+@app.route('/admin')
+@login_required
+def admin_dashboard():
+    if current_user.role != 'admin':
+        return redirect(url_for('dashboard'))
+    sales = Sale.query.all()
+    total = sum(s.price for s in sales if s.price)
+    return render_template('admin_dashboard.html', sales=sales, total=total)
+
+@app.route('/sale/new', methods=['GET', 'POST'])
+@login_required
+def new_sale():
+    if current_user.role != 'franchisee':
+        return redirect(url_for('dashboard'))
+    if request.method == 'POST':
+        description = request.form['description']
+        address = request.form['address']
+        zip_code = request.form['zip_code']
+        first = request.form['customer_first']
+        last = request.form['customer_last']
+        phone = request.form['phone']
+        payment_method = request.form['payment_method']
+        price = request.form['price']
+        before_file = request.files['before_image']
+        after_file = request.files['after_image']
+        proof_file = request.files['proof_image']
+
+        def save_file(f):
+            if f and f.filename:
+                path = os.path.join(app.config['UPLOAD_FOLDER'], f.filename)
+                f.save(path)
+                return f.filename
+            return None
+
+        before_filename = save_file(before_file)
+        after_filename = save_file(after_file)
+        proof_filename = save_file(proof_file)
+        sale = Sale(
+            user_id=current_user.id,
+            description=description,
+            address=address,
+            zip_code=zip_code,
+            customer_first=first,
+            customer_last=last,
+            phone=phone,
+            payment_method=payment_method,
+            price=float(price) if price else 0,
+            before_image=before_filename,
+            after_image=after_filename,
+            proof_image=proof_filename,
+        )
+        db.session.add(sale)
+        db.session.commit()
+        return redirect(url_for('dashboard'))
+    return render_template('sale_form.html')
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/app/templates/admin_dashboard.html
+++ b/app/templates/admin_dashboard.html
@@ -1,0 +1,28 @@
+{% extends 'base.html' %}
+{% block title %}Admin Dashboard{% endblock %}
+{% block content %}
+<h2>All Sales</h2>
+<table class="table">
+    <thead>
+        <tr>
+            <th>User</th>
+            <th>Description</th>
+            <th>Address</th>
+            <th>Customer</th>
+            <th>Price</th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for sale in sales %}
+        <tr>
+            <td>{{ sale.user_id }}</td>
+            <td>{{ sale.description }}</td>
+            <td>{{ sale.address }} {{ sale.zip_code }}</td>
+            <td>{{ sale.customer_first }} {{ sale.customer_last }}</td>
+            <td>{{ sale.price }}</td>
+        </tr>
+        {% endfor %}
+    </tbody>
+</table>
+<p>Total sales: {{ total }}</p>
+{% endblock %}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>{% block title %}SaaS App{% endblock %}</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-light bg-light">
+    <div class="container-fluid">
+        <a class="navbar-brand" href="/">SaaS</a>
+        <div class="collapse navbar-collapse">
+            <ul class="navbar-nav ms-auto">
+                {% if current_user.is_authenticated %}
+                <li class="nav-item"><a class="nav-link" href="{{ url_for('logout') }}">Logout</a></li>
+                {% endif %}
+            </ul>
+        </div>
+    </div>
+</nav>
+<div class="container mt-4">
+    {% with messages = get_flashed_messages() %}
+        {% if messages %}
+            <div class="alert alert-warning">{{ messages[0] }}</div>
+        {% endif %}
+    {% endwith %}
+    {% block content %}{% endblock %}
+</div>
+</body>
+</html>

--- a/app/templates/calendar.html
+++ b/app/templates/calendar.html
@@ -1,0 +1,18 @@
+{% extends 'base.html' %}
+{% block title %}Calendar{% endblock %}
+{% block content %}
+<h2>Upcoming Jobs</h2>
+<table class="table">
+    <thead>
+        <tr><th>Date</th><th>Title</th></tr>
+    </thead>
+    <tbody>
+        {% for job in jobs %}
+        <tr>
+            <td>{{ job.scheduled_for.strftime('%Y-%m-%d') }}</td>
+            <td>{{ job.title }}</td>
+        </tr>
+        {% endfor %}
+    </tbody>
+</table>
+{% endblock %}

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -1,0 +1,37 @@
+{% extends 'base.html' %}
+{% block title %}Dashboard{% endblock %}
+{% block content %}
+<div class="row mb-4 text-center">
+    <div class="col-md-4 mb-3">
+        <a class="btn btn-outline-primary w-100" href="{{ url_for('calendar') }}">Calendar</a>
+    </div>
+    <div class="col-md-4 mb-3">
+        <a class="btn btn-outline-primary w-100" href="{{ url_for('performance') }}">Performance</a>
+    </div>
+    <div class="col-md-4 mb-3">
+        <a class="btn btn-success w-100" href="{{ url_for('new_sale') }}">Make an Order</a>
+    </div>
+</div>
+
+<h3>Your Recent Sales</h3>
+<table class="table">
+    <thead>
+        <tr>
+            <th>Description</th>
+            <th>Address</th>
+            <th>Customer</th>
+            <th>Price</th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for sale in sales %}
+        <tr>
+            <td>{{ sale.description }}</td>
+            <td>{{ sale.address }} {{ sale.zip_code }}</td>
+            <td>{{ sale.customer_first }} {{ sale.customer_last }}</td>
+            <td>{{ sale.price }}</td>
+        </tr>
+        {% endfor %}
+    </tbody>
+</table>
+{% endblock %}

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -1,0 +1,16 @@
+{% extends 'base.html' %}
+{% block title %}Login{% endblock %}
+{% block content %}
+<h2>Login</h2>
+<form method="post">
+    <div class="mb-3">
+        <label class="form-label">Username</label>
+        <input class="form-control" type="text" name="username" required>
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Password</label>
+        <input class="form-control" type="password" name="password" required>
+    </div>
+    <button class="btn btn-primary" type="submit">Login</button>
+</form>
+{% endblock %}

--- a/app/templates/performance.html
+++ b/app/templates/performance.html
@@ -1,0 +1,10 @@
+{% extends 'base.html' %}
+{% block title %}Performance{% endblock %}
+{% block content %}
+<h2>Performance Metrics</h2>
+<ul>
+    <li>Total Sales: {{ total }}</li>
+    <li>Number of Jobs: {{ count }}</li>
+    <li>Average Revenue per Job: {{ average }}</li>
+</ul>
+{% endblock %}

--- a/app/templates/sale_form.html
+++ b/app/templates/sale_form.html
@@ -1,0 +1,59 @@
+{% extends 'base.html' %}
+{% block title %}New Sale{% endblock %}
+{% block content %}
+<h2>Record a Sale</h2>
+<form method="post" enctype="multipart/form-data">
+    <div class="mb-3">
+        <label class="form-label">Description</label>
+        <textarea class="form-control" name="description" required></textarea>
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Before Image</label>
+        <input class="form-control" type="file" name="before_image">
+    </div>
+    <div class="mb-3">
+        <label class="form-label">After Image</label>
+        <input class="form-control" type="file" name="after_image">
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Address</label>
+        <input class="form-control" type="text" name="address">
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Zip Code</label>
+        <input class="form-control" type="text" name="zip_code">
+    </div>
+    <div class="row">
+        <div class="col-md-6 mb-3">
+            <label class="form-label">Customer First Name</label>
+            <input class="form-control" type="text" name="customer_first">
+        </div>
+        <div class="col-md-6 mb-3">
+            <label class="form-label">Customer Last Name</label>
+            <input class="form-control" type="text" name="customer_last">
+        </div>
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Customer Phone</label>
+        <input class="form-control" type="text" name="phone">
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Payment Method</label>
+        <select class="form-select" name="payment_method">
+            <option value="cash">Cash</option>
+            <option value="check">Check</option>
+            <option value="credit">Credit</option>
+            <option value="other">Other</option>
+        </select>
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Proof of Payment</label>
+        <input class="form-control" type="file" name="proof_image">
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Price</label>
+        <input class="form-control" type="number" step="0.01" name="price">
+    </div>
+    <button class="btn btn-primary" type="submit">Submit</button>
+</form>
+{% endblock %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+Flask
+Flask_SQLAlchemy
+Flask_Login


### PR DESCRIPTION
## Summary
- implement models for expanded sale data and jobs
- add calendar and performance pages
- update dashboard template with navigation tiles
- improve sale form for customer info and payment proof
- document features in README

## Testing
- `python3 -m py_compile app/app.py`


------
https://chatgpt.com/codex/tasks/task_e_68572446246c833193df3b8ae28eaee4